### PR TITLE
Remove unnecessary locks

### DIFF
--- a/include/node_example/talker.h
+++ b/include/node_example/talker.h
@@ -5,9 +5,6 @@
 #include <ros/ros.h>
 #include <ros/time.h>
 
-// Boost includes for mutex.
-#include <boost/thread.hpp>
-
 // Custom message includes. Auto-generated from msg/ directory.
 #include <node_example/NodeExampleData.h>
 
@@ -48,9 +45,6 @@ class ExampleTalker
 
   //! The second integer to use in addition.
   int b_;
-
-  //! Mutex to protect writing data in multiple places.
-  boost::mutex mutex_;
 
   //! Flag to set whether the node should do any work at all.
   bool enable_;

--- a/src/talker.cpp
+++ b/src/talker.cpp
@@ -31,7 +31,6 @@ ExampleTalker::ExampleTalker(ros::NodeHandle nh) : message_("hello"), a_(1), b_(
 
 void ExampleTalker::timerCallback(const ros::TimerEvent &event)
 {
-  boost::unique_lock<boost::mutex> lock(mutex_);
   if (!enable_)
   {
     return;
@@ -41,7 +40,6 @@ void ExampleTalker::timerCallback(const ros::TimerEvent &event)
   msg.message = message_;
   msg.a = a_;
   msg.b = b_;
-  lock.unlock();
 
   pub_.publish(msg);
 }
@@ -49,7 +47,6 @@ void ExampleTalker::timerCallback(const ros::TimerEvent &event)
 void ExampleTalker::configCallback(node_example::nodeExampleConfig &config, uint32_t level)
 {
   // Set class variables to new values. They should match what is input at the dynamic reconfigure GUI.
-  boost::unique_lock<boost::mutex> lock(mutex_);
   message_ = config.message;
   a_ = config.a;
   b_ = config.b;


### PR DESCRIPTION
Removing boost mutexes and locks. They are not necessary because I am using a simple ROS spin thread which enters callbacks serially.