### PR TITLE
changing NodeExample()'s a, b, and msg.data such that they are accessible from the CLI

### DIFF
--- a/src/pytalker.py
+++ b/src/pytalker.py
@@ -29,9 +29,16 @@ class NodeExample(object):
         self.pub = rospy.Publisher('example', NodeExampleData, queue_size=10)
         # Initialize message variables.
         self.enable = rospy.get_param('~enable', True)
-        self.int_a = rospy.get_param('a', 1)
-        self.int_b = rospy.get_param('b', 2)
+        # Define int_a and int_b also as private variables
+        # such that they can be specified from the command line
+        self.int_a = rospy.get_param('~a', 1)
+        self.int_b = rospy.get_param('~b', 2)
         self.message = rospy.get_param('~message', 'hello')
+
+        # Add ros log information display
+        rospy.loginfo('a = %d', self.int_a)
+        rospy.loginfo('b = %d', self.int_b)
+        rospy.loginfo('message = %s', self.message)
 
         # Create a timer to go to a callback. This is more accurate than
         # sleeping for a specified time.
@@ -51,9 +58,28 @@ class NodeExample(object):
         msg = NodeExampleData()
         # Fill in custom message variables with values updated from dynamic
         # reconfigure server.
-        msg.message = self.message
-        msg.a = self.int_a
-        msg.b = self.int_b
+        # Change message expressions such that they can be also specified using
+        # $ rosparam set /pytalker/a 100
+        # $ rosparam set /pytalker/b 200
+        # $ rosparam set /pytalker/message "Hi"
+        msg.message = rospy.get_param('~message', self.message)
+        msg.a = rospy.get_param('~a', self.int_a)
+        msg.b = rospy.get_param('~b', self.int_b)
+
+        # If changes are detected, display ros log informing the changes
+        if self.message != msg.message:
+            rospy.loginfo('new message = %s', msg.message)
+        if self.int_a != msg.a:
+            rospy.loginfo('new a = %d', msg.a)
+        if self.int_b != msg.b:
+            rospy.loginfo('new b = %d', msg.b)
+
+        # Assign private variables to newly assigned values such that
+        # the notification about change won't come up in every callback
+        self.message = msg.message
+        self.int_a = msg.a
+        self.int_b = msg.b
+
         # Publish our custom message.
         self.pub.publish(msg)
 


### PR DESCRIPTION
Hi Thomas,

Thank you for your reply for my last issue, that was very helpful! I made the some changes to your code based on the following reasons.

- On your [ROSNodeTutorialPython](http://wiki.ros.org/ROSNodeTutorialPython) section 3.1, I saw you put a demo command `rosrun node_example pytalker.py _message:="Hello world!" _a:=57 _b:=-15 _rate:=1`. So I thought you might want that a and b are accessible from the CLI. So I made some changes for that with some roslog information.

- In the `timer_cb()`, again, the msg.data are not accessible from the CLI (only accessible from the dynamic parameter sever), so I changed/added the some code to make them accessible from the CLI using `$ rosparam set /pytalker/a 100`, `$ rosparam set /pytalker/b 200`, `$ rosparam set /pytalker/message "Hi"`, with a piece of check code showing roslog information if changes are detected. With that from the CLI one can see:
> ~/zongyao_ws/ros_ws$ rosrun node_example pytalker.py _a:=10 _b:=20 _message:="Howdy"
> [INFO] [1502505931.496516]: rate = 1.000000
> [INFO] [1502505931.518034]: a = 10
> [INFO] [1502505931.518251]: b = 20
> [INFO] [1502505931.518387]: message = Howdy
> [INFO] [1502505937.535643]: new a = 100
> [INFO] [1502505941.537330]: new b = 200
> [INFO] [1502505948.523191]: new message = Hi

You repos are really helpful, again, thank you!

Sincerely,
Zongyao