### PR TITLE
Clang tidy updates

### DIFF
--- a/src/talker.cpp
+++ b/src/talker.cpp
@@ -11,7 +11,7 @@ ExampleTalker::ExampleTalker(ros::NodeHandle nh) : message_("hello"), a_(1), b_(
   dr_srv_.setCallback(cb);
 
   // Declare variables that can be modified by launch file or command line.
-  int rate;
+  int rate = 1;
 
   // Initialize node parameters from launch file or command line. Use a private node handle so that multiple instances
   // of the node can be run simultaneously while using different parameters.
@@ -19,7 +19,7 @@ ExampleTalker::ExampleTalker(ros::NodeHandle nh) : message_("hello"), a_(1), b_(
   pnh.param("a", a_, a_);
   pnh.param("b", b_, b_);
   pnh.param("message", message_, message_);
-  pnh.param("rate", rate, 1);
+  pnh.param("rate", rate, rate);
   pnh.param("enable", enable_, enable_);
 
   // Create a publisher and name the topic.

--- a/test/test_node_example_listener.cpp
+++ b/test/test_node_example_listener.cpp
@@ -34,7 +34,7 @@ class Helper
     return got_msg_;
   }
 
-  void sendData(double a, double b, std::string message)
+  void sendData(double a, double b, const std::string &message)
   {
     node_example::NodeExampleData msg;
     msg.a = a;


### PR DESCRIPTION
Fix clang-tidy warning about passing by reference instead of value. Initializing a variable.