### PR TITLE
Unused parameters warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,9 +36,11 @@ if(CATKIN_ENABLE_TESTING)
 
   add_rostest_gtest(test_node_example_talker test/test_node_example_talker.test test/test_node_example_talker.cpp)
   target_link_libraries(test_node_example_talker ${catkin_LIBRARIES})
+  add_dependencies(test_node_example_talker node_example_generate_messages_cpp)
 
   add_rostest_gtest(test_node_example_listener test/test_node_example_listener.test test/test_node_example_listener.cpp)
   target_link_libraries(test_node_example_listener ${catkin_LIBRARIES})
+  add_dependencies(test_node_example_listener node_example_generate_messages_cpp)
 endif()
 
 

--- a/src/talker.cpp
+++ b/src/talker.cpp
@@ -42,7 +42,7 @@ void ExampleTalker::stop()
   pub_.shutdown();
 }
 
-void ExampleTalker::timerCallback(const ros::TimerEvent &event)
+void ExampleTalker::timerCallback(const ros::TimerEvent &event __attribute__((unused)))
 {
   if (!enable_)
   {
@@ -57,7 +57,7 @@ void ExampleTalker::timerCallback(const ros::TimerEvent &event)
   pub_.publish(msg);
 }
 
-void ExampleTalker::configCallback(node_example::nodeExampleConfig &config, uint32_t level)
+void ExampleTalker::configCallback(node_example::nodeExampleConfig &config, uint32_t level __attribute__((unused)))
 {
   // Set class variables to new values. They should match what is input at the dynamic reconfigure GUI.
   message_ = config.message;

--- a/test/test_node_example_listener.cpp
+++ b/test/test_node_example_listener.cpp
@@ -58,7 +58,7 @@ class Helper
     }
   }
 
-  void rosoutCallback(const rosgraph_msgs::LogConstPtr &msg)
+  void rosoutCallback(const rosgraph_msgs::LogConstPtr &msg __attribute__((unused)))
   {
     got_msg_ = true;
   }

--- a/test/test_node_example_talker.cpp
+++ b/test/test_node_example_talker.cpp
@@ -67,7 +67,7 @@ class Helper
     }
   }
 
-  void exampleCallback(const node_example::NodeExampleDataConstPtr &msg)
+  void exampleCallback(const node_example::NodeExampleDataConstPtr &msg __attribute__((unused)))
   {
     got_msg_ = true;
   }


### PR DESCRIPTION
Fixed warnings about unused parameters based on SEI CERT C Coding Standard.

https://wiki.sei.cmu.edu/confluence/display/c/MSC12-C.+Detect+and+remove+code+that+has+no+effect+or+is+never+executed