### PR TITLE
Fix timer frequency

### DIFF
--- a/src/talker.cpp
+++ b/src/talker.cpp
@@ -29,7 +29,7 @@ ExampleTalker::ExampleTalker(ros::NodeHandle nh) : nh_(nh), message_("hello"), a
   }
 
   // Create timer.
-  timer_ = nh_.createTimer(ros::Duration(1 / rate), &ExampleTalker::timerCallback, this);
+  timer_ = nh_.createTimer(ros::Duration(1.0 / rate), &ExampleTalker::timerCallback, this);
 }
 
 void ExampleTalker::start()


### PR DESCRIPTION
The division of an integer by an integer results in an integer. However in the case of a rate > 1 (e.g. 10) we need the resulting frequency to be of type double.