### PR TITLE
Updates for ROS Noetic compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ install(DIRECTORY include/${PROJECT_NAME}/
   FILES_MATCHING PATTERN "*.h"
 )
 
-install(PROGRAMS src/pylistener.py src/pytalker.py DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+catkin_install_python(PROGRAMS src/pylistener.py src/pytalker.py DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 install(TARGETS listener talker
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(node_example)
 
 find_package(catkin REQUIRED COMPONENTS dynamic_reconfigure message_generation roscpp rosgraph_msgs rospy std_msgs)


### PR DESCRIPTION
Two changes to make this compatible with ROS Noetic. See the [guide on Using Python 3](http://wiki.ros.org/UsingPython3/) and the [Noetic Migration Guide](http://wiki.ros.org/noetic/Migration).

See https://answers.ros.org/question/361966/rosrun-still-use-python27-instead-of-38-inside-noetic

---

 Bump CMake version to avoid CMP0048

This bumps the minimum CMake version to 3.0.2, which is the minimum supported by ROS Kinetic and new enough to default to the NEW behavior of CMP0048. This avoids a CMake warning when building and testing this package in Debian Buster and Ubuntu Focal.

See ros/catkin#1052

---
 Use catkin_install_python

Uses catkin_install_python() so scripts are installed with the correct
shebang for the given version of ROS.

http://wiki.ros.org/UsingPython3/SourceCodeChanges#Changing_shebangs

---

